### PR TITLE
Feature/device logging

### DIFF
--- a/SuperDBCore/SuperDBCore/SuperInterpreter.m
+++ b/SuperDBCore/SuperDBCore/SuperInterpreter.m
@@ -98,7 +98,7 @@
 			
 			if (nil == [result result]) {
 				NSLog(@"[ERROR]: [result result] was nil... result is: %@", result);
-				[body setObject:@"Empty result. This usually means you sent a message to the wrong view controller. Try calling `.self` and trying again." forKey:kSuperNetworkMessageBodyOutputKey];
+				[body setObject:@"Empty result. This usually means you sent a message to a nil pointer." forKey:kSuperNetworkMessageBodyOutputKey];
 			} else {
 				[body setObject:[[result result] description] forKey:kSuperNetworkMessageBodyOutputKey];
 			}

--- a/SuperDBCore/SuperDBCore/SuperInterpreter.m
+++ b/SuperDBCore/SuperDBCore/SuperInterpreter.m
@@ -17,6 +17,9 @@
 #import "Geometry.h"
 
 
+#define kSuperDebuggerDeviceLogDefaultsKey @"org.superdb.device.log_settings"
+#define USE_LOGGING [[NSUserDefaults standardUserDefaults] boolForKey:kSuperDebuggerDeviceLogDefaultsKey]
+
 @interface SuperInterpreter ()
 @property (nonatomic, strong) NSMutableDictionary *requestHandlers;
 @property (nonatomic, strong) FSInterpreter *interpreter;
@@ -68,6 +71,13 @@
 	
 	// Add custom classes to the environment
 	[self.interpreter setObject:[Geometry class] forIdentifier:NSStringFromClass([Geometry class])];
+	
+	
+	// Enable logging by default
+	if ([[NSUserDefaults standardUserDefaults] objectForKey:kSuperDebuggerDeviceLogDefaultsKey] == nil) {
+		NSLog(@"[SuperDB]: Enabling device-side logs of interpreter input+output. These are stored in the defaults. To turn off, use `.logging off`");
+		[[NSUserDefaults standardUserDefaults] setBool:YES forKey:kSuperDebuggerDeviceLogDefaultsKey];
+	}
 }
 
 
@@ -78,7 +88,7 @@
 	[self addRequestHandlerForResource:kSuperNetworkMessageResourceInterpreter requestHandler:^SuperNetworkMessage *(SuperNetworkMessage *request) {
 		
 		NSString *input = [[request body] objectForKey:kSuperNetworkMessageBodyInputKey];
-		FSInterpreterResult *result = [weakSelf interpreterResultForInput:input logResult:YES];
+		FSInterpreterResult *result = [weakSelf interpreterResultForInput:input logResult:USE_LOGGING];
 		
 		NSMutableDictionary *body = [@{} mutableCopy];
 		
@@ -117,7 +127,7 @@
 	
 	[self addRequestHandlerForResource:kSuperNetworkMessageResourceClassList requestHandler:^SuperNetworkMessage *(SuperNetworkMessage *request) {
 		NSArray *classList = classNames();
-		if ([self.projectPrefix length])
+		if ([weakSelf.projectPrefix length])
 			classList = [classList filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"SELF like[c] %@", [NSString stringWithFormat:@"%@*", self.projectPrefix]]];
 		
 		NSMutableDictionary *body = [@{} mutableCopy];
@@ -136,7 +146,7 @@
 		NSString *input = [[request body] objectForKey:kSuperNetworkMessageBodyInputKey];
 		SuperInterpreterObjectBrowser *objectBrowser = [SuperInterpreterObjectBrowser new];
 		
-		FSInterpreterResult *result = [weakSelf interpreterResultForInput:input logResult:YES];
+		FSInterpreterResult *result = [weakSelf interpreterResultForInput:input logResult:USE_LOGGING];
 		
 		
 		NSLog(@"[SERVER]: Loading properties for input: %@", input);
@@ -166,7 +176,7 @@
 		NSString *input = [[request body] objectForKey:kSuperNetworkMessageBodyInputKey];
 		SuperInterpreterObjectBrowser *objectBrowser = [SuperInterpreterObjectBrowser new];
 		
-		FSInterpreterResult *result = [weakSelf interpreterResultForInput:input logResult:YES];
+		FSInterpreterResult *result = [weakSelf interpreterResultForInput:input logResult:USE_LOGGING];
 		
 		
 		NSLog(@"[SERVER]: Loading methods for input: %@", input);
@@ -191,7 +201,7 @@
 	}];
 	
 	
-	[self addRequestHandlerForResource:kSuperNetworkMessageResourceUpdateCurrentViewController requestHandler:^SuperNetworkMessage *(SuperNetworkMessage *request) {
+	[self addRequestHandlerForResource:kSuperNetworkMessageResourceUpdateCurrentSelfPointer requestHandler:^SuperNetworkMessage *(SuperNetworkMessage *request) {
 		NSLog(@"[SERVER]: Updating the current view controller.");
 		NSMutableDictionary *body = [@{} mutableCopy];
 #if !TARGET_OS_IPHONE
@@ -200,8 +210,8 @@
 		// Defaults to the window's rootViewController
 		id newSelf = [[[UIApplication sharedApplication] keyWindow] rootViewController];
 #endif
-		if (self.currentSelfPointerBlock) {
-			newSelf = self.currentSelfPointerBlock();
+		if (weakSelf.currentSelfPointerBlock) {
+			newSelf = weakSelf.currentSelfPointerBlock();
 		}
 		
 		// Assign this view controller in the environment
@@ -209,7 +219,7 @@
 		
 		// Evaluate self and get the result to be returned to the client
 		// Sure, could just pass in the actual view controller, but I'd rather hear it straight from the interpreter.
-		FSInterpreterResult *result = [weakSelf interpreterResultForInput:@"self" logResult:YES];
+		FSInterpreterResult *result = [weakSelf interpreterResultForInput:@"self" logResult:USE_LOGGING];
 		if ([result isOK]) {
 			[body setObject:kSuperNetworkMessageBodyStatusOK forKey:kSuperNetworkMessageBodyStatusKey];
 			[body setObject:[[result result] description] forKey:kSuperNetworkMessageBodyOutputKey];
@@ -221,6 +231,28 @@
 			NSRange range = [result errorRange];
 			[body setObject:NSStringFromRange(range) forKey:kSuperNetworkMessageBodyErrorRange];
 		}
+		SuperNetworkMessage *response = [SuperNetworkMessage messageWithHeader:request.header body:body];
+		return response;
+	}];
+	
+	
+	[self addRequestHandlerForResource:kSuperNetworkMessageResourceDeviceLoggingSettings requestHandler:^SuperNetworkMessage *(SuperNetworkMessage *request) {
+		
+		NSString *input = [[request body] objectForKey:kSuperNetworkMessageBodyInputKey];
+		
+		BOOL shouldSet = NO;
+		if ([input compare:@"on" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+			shouldSet = YES;
+		}
+		[[NSUserDefaults standardUserDefaults] setBool:shouldSet forKey:kSuperDebuggerDeviceLogDefaultsKey];
+		NSString *output = [NSString stringWithFormat:@"Device logging is %@.", shouldSet? @"on" : @"off"];
+		
+		NSMutableDictionary *body = [@{} mutableCopy];
+		
+		[body setObject:kSuperNetworkMessageBodyStatusOK forKey:kSuperNetworkMessageBodyStatusKey];
+		[body setObject:output forKey:kSuperNetworkMessageBodyOutputKey];
+		
+		
 		SuperNetworkMessage *response = [SuperNetworkMessage messageWithHeader:request.header body:body];
 		return response;
 	}];

--- a/SuperDBCore/SuperDBCore/SuperNetworkMessage.m
+++ b/SuperDBCore/SuperDBCore/SuperNetworkMessage.m
@@ -32,7 +32,8 @@ NSString *kSuperNetworkMessageResourceSymbolTable = @"smybol_table";
 NSString *kSuperNetworkMessageResourceClassList = @"class_list";
 NSString *kSuperNetworkMessageResourcePropertyList = @"property_list";
 NSString *kSuperNetworkMessageResourceMethodList = @"method_list";
-NSString *kSuperNetworkMessageResourceUpdateCurrentViewController = @"update_current_viewcontroller";
+NSString *kSuperNetworkMessageResourceUpdateCurrentSelfPointer = @"update_current_self_pointer";
+NSString *kSuperNetworkMessageResourceDeviceLoggingSettings = @"device_logging";
 
 
 @interface SuperNetworkMessage ()
@@ -48,7 +49,8 @@ NSString *kSuperNetworkMessageResourceUpdateCurrentViewController = @"update_cur
 	resourceTypes = @{	@".prop" : kSuperNetworkMessageResourcePropertyList,
 						@".classes" : kSuperNetworkMessageResourceClassList,
 						@".methods" : kSuperNetworkMessageResourceMethodList,
-						@".self" : kSuperNetworkMessageResourceUpdateCurrentViewController};
+						@".self" : kSuperNetworkMessageResourceUpdateCurrentSelfPointer,
+						@".logging" : kSuperNetworkMessageResourceDeviceLoggingSettings};
 }
 
 

--- a/SuperDBCore/SuperDBCore/SuperNetworkMessageTypes.h
+++ b/SuperDBCore/SuperDBCore/SuperNetworkMessageTypes.h
@@ -35,7 +35,8 @@ extern NSString *kSuperNetworkMessageResourceSymbolTable;
 extern NSString *kSuperNetworkMessageResourceClassList;
 extern NSString *kSuperNetworkMessageResourcePropertyList;
 extern NSString *kSuperNetworkMessageResourceMethodList;
-extern NSString *kSuperNetworkMessageResourceUpdateCurrentViewController;
+extern NSString *kSuperNetworkMessageResourceUpdateCurrentSelfPointer;
+extern NSString *kSuperNetworkMessageResourceDeviceLoggingSettings;
 
 #pragma mark - JSTP defines
 #define kJSTPHeaderTag 6000

--- a/SuperDebug/Super Debug/SuperDebugAreaWindowController.m
+++ b/SuperDebug/Super Debug/SuperDebugAreaWindowController.m
@@ -97,8 +97,7 @@
 	
 	[self.shellContainer.shellView setNumberDragHandler:^(id draggedItem) {
 		[self.networkClient requestWithStringToEvaluate:draggedItem responseHandler:^(SuperNetworkMessage *response) {
-			NSLog(@"%@", draggedItem);
-			[response log];
+			// Do something with the response if you'd like.
 		}];
 	}];
 	

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,47 @@ See below for precise installation instructions, how to make use of the debugger
 Installation
 ------------
 
+1. Add the repository as a submodule to your Project's repository
+
+	>git submodule add https://github.com/Shopify/superdb.git MyApp/Libraries/superdb
+
+2. Find the superdbCore project in Finder and drag it in to your currently open Xcode project. This will add it as a subproject.
+
+3. In your Target's settings, expand the "Link with Libraries" section, press the + icon, and add the libSuperDBCore.a library.
+
+4. Also add the `CFNetwork.framework` in the same way.
+
+5. On the "Build Settings" for your Target, find the "Header Search Paths" setting and add an entry (for at least your Debug configuration or optionally all configurations). This entry should be for `$(BUILT_PRODUCTS_DIR)` and it should be marked as `recursive`.
+
+6. Next, pick which class is going to house your Interpreter service. A good spot for this is your AppDelegate.
+
+7. In your file, add `#import <SuperDBCore/SuperDBCore.h>`.
+
+8. Create an instance variable or property for `SuperInterpreterService *_interpreterService;`
+
+9. Initialze as follows:
+
+	_interpreterService = [SuperInterpreterService new];
+	if ([_interpreterService startServer]) {
+		[_interpreterService publishServiceWithCallback:^(id success, NSDictionary *errorDictionary) {
+			if (errorDictionary) {
+				NSLog(@"There was a problem starting the SuperDebugger service: %@", errorDictionary);
+				return;
+			}
+			
+			// The service is now on the network, ready to run interpreter events.
+		}];
+	}
+	[_interpreterService setCurrentSelfPointerBlock:^id {
+		// Return whatever you'd like to be pointed to by `self`.
+		// This might be whatever your topmost view controller is
+		// How you get it is up to you!
+		// return _navigationController.topViewController;
+		return _customMenuSystem.rootViewController;
+	}];
+
+You should be good to go. Fire up the app in either the Simulator or on a device, and launch the Super Debugger Mac app, double click your app in the list, and debug away! The only requirement is the apps be on the same local network (This could potentially work over a WAN, too, but for now we use Bonjour for finding devices. WAN would have higher latency, too).
+
 Demo application
 ----------------
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Installation
 
 1. Add the repository as a submodule to your Project's repository
 
-	>git submodule add https://github.com/Shopify/superdb.git MyApp/Libraries/superdb
+		\>git submodule add https://github.com/Shopify/superdb.git MyApp/Libraries/superdb
 
 2. Find the superdbCore project in Finder and drag it in to your currently open Xcode project. This will add it as a subproject.
 
@@ -34,24 +34,24 @@ Installation
 
 9. Initialze as follows:
 
-	_interpreterService = [SuperInterpreterService new];
-	if ([_interpreterService startServer]) {
-		[_interpreterService publishServiceWithCallback:^(id success, NSDictionary *errorDictionary) {
-			if (errorDictionary) {
-				NSLog(@"There was a problem starting the SuperDebugger service: %@", errorDictionary);
-				return;
-			}
-			
-			// The service is now on the network, ready to run interpreter events.
+		_interpreterService = [SuperInterpreterService new];
+		if ([_interpreterService startServer]) {
+			[_interpreterService publishServiceWithCallback:^(id success, NSDictionary *errorDictionary) {
+				if (errorDictionary) {
+					NSLog(@"There was a problem starting the SuperDebugger service: %@", errorDictionary);
+					return;
+				}
+				
+				// The service is now on the network, ready to run interpreter events.
+			}];
+		}
+		[_interpreterService setCurrentSelfPointerBlock:^id {
+			// Return whatever you'd like to be pointed to by `self`.
+			// This might be whatever your topmost view controller is
+			// How you get it is up to you!
+			// return _navigationController.topViewController;
+			return _customMenuSystem.rootViewController;
 		}];
-	}
-	[_interpreterService setCurrentSelfPointerBlock:^id {
-		// Return whatever you'd like to be pointed to by `self`.
-		// This might be whatever your topmost view controller is
-		// How you get it is up to you!
-		// return _navigationController.topViewController;
-		return _customMenuSystem.rootViewController;
-	}];
 
 You should be good to go. Fire up the app in either the Simulator or on a device, and launch the Super Debugger Mac app, double click your app in the list, and debug away! The only requirement is the apps be on the same local network (This could potentially work over a WAN, too, but for now we use Bonjour for finding devices. WAN would have higher latency, too).
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Installation
 
 1. Add the repository as a submodule to your Project's repository
 
-		\>git submodule add https://github.com/Shopify/superdb.git MyApp/Libraries/superdb
+		>git submodule add https://github.com/Shopify/superdb.git MyApp/Libraries/superdb
 
 2. Find the superdbCore project in Finder and drag it in to your currently open Xcode project. This will add it as a subproject.
 


### PR DESCRIPTION
Adds a logging functionality, enabled by default, to the app. This will log all interpreter commands and their results.

It might have performance problems for using the dragging functionality. This should be tested, and if so a way should be added to skip logging just these.

Turn on from the Mac app with `.logging on` and turn off with `.logging off` (or `logging fdashfdjsafhdjsaklfdsaAnythingButOn`).
