### PR TITLE
README.md: Remove query params from screenshot URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ You can then send messages to your live objects as the app is running on the dev
 
 The debugger will even let you rapidly resend messages involving numeric values. When trying to tweak an interface measurement, for example, you can just click and drag on the value and see the changes reflected instantly on the device.
 
-![Super Debugger running on a Mac debugging an included iOS app.](https://raw.github.com/Shopify/superdb/develop/screenshot.png?login=jbrennan&token=1080ab57c1c5e5a1f4f9481d10e2e640 "Super Debugger running on a Mac debugging an included iOS app.")
+![Super Debugger running on a Mac debugging an included iOS app.](https://raw.github.com/Shopify/superdb/develop/screenshot.png "Super Debugger running on a Mac debugging an included iOS app.")
 
 See below for precise installation instructions, how to make use of the debugger, and how you can contribute.
 


### PR DESCRIPTION
The screenshot URL had what appear to be unnecessary `login` and `token` query parameters.

(Also, it might be a good idea to optimize that screenshot. 6.3 MB is a bit heavy for a readme intended to be viewed on the Web.)
