### PR TITLE
Fix the loading of F-Script categories in the "Debug Me" demo project

### DIFF
--- a/Debug Me/Debug Me.xcodeproj/project.pbxproj
+++ b/Debug Me/Debug Me.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 				GCC_PREFIX_HEADER = "Debug Me/Debug Me-Prefix.pch";
 				HEADER_SEARCH_PATHS = "../SuperDBCore/SuperDBCore/**";
 				INFOPLIST_FILE = "Debug Me/Debug Me-Info.plist";
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -287,6 +288,7 @@
 				GCC_PREFIX_HEADER = "Debug Me/Debug Me-Prefix.pch";
 				HEADER_SEARCH_PATHS = "../SuperDBCore/SuperDBCore/**";
 				INFOPLIST_FILE = "Debug Me/Debug Me-Info.plist";
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};


### PR DESCRIPTION
This allow to use expressions such as "setFrame:(10<>10 extent:50<>20)", which requires the "extent:" method to be defined on NSValue.
