### PR TITLE
Added a command to display UIImages them on the Mac client

### DIFF
--- a/Debug Me/Debug Me/DBMEAppDelegate.m
+++ b/Debug Me/Debug Me/DBMEAppDelegate.m
@@ -10,6 +10,30 @@
 
 #import "DBMEViewController.h"
 #import <SuperDBCore/SuperDBCore.h>
+#import <QuartzCore/QuartzCore.h>
+
+
+
+@implementation UIView (Screenshot)
+
+// Generate an image of the receiver appearance.
+// TODO: Improve the target resolution of the generated photo. See that page, to do so:
+// http://stackoverflow.com/questions/2500915/how-to-create-an-image-from-a-uiview-uiscrollview
+- (UIImage *)generateImage
+{
+    UIGraphicsBeginImageContext(self.frame.size);
+    CGContextRef generatingContext = UIGraphicsGetCurrentContext();
+    
+    [self.layer renderInContext:generatingContext];
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return newImage;
+}
+
+@end
+
+
 
 @implementation DBMEAppDelegate {
 	SuperInterpreterService *_interpreterService;

--- a/Debug Me/Debug Me/DBMEAppDelegate.m
+++ b/Debug Me/Debug Me/DBMEAppDelegate.m
@@ -10,28 +10,6 @@
 
 #import "DBMEViewController.h"
 #import <SuperDBCore/SuperDBCore.h>
-#import <QuartzCore/QuartzCore.h>
-
-
-
-@implementation UIView (Screenshot)
-
-// Generate an image of the receiver appearance.
-// TODO: Improve the target resolution of the generated photo. See that page, to do so:
-// http://stackoverflow.com/questions/2500915/how-to-create-an-image-from-a-uiview-uiscrollview
-- (UIImage *)generateImage
-{
-    UIGraphicsBeginImageContext(self.frame.size);
-    CGContextRef generatingContext = UIGraphicsGetCurrentContext();
-    
-    [self.layer renderInContext:generatingContext];
-    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    
-    return newImage;
-}
-
-@end
 
 
 

--- a/SuperDBCore/SuperDBCore.xcodeproj/project.pbxproj
+++ b/SuperDBCore/SuperDBCore.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4E1C7FE816BBD4E100C2F881 /* NSData+Base64.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E1C7FE516BBD4E100C2F881 /* NSData+Base64.h */; };
+		4E1C7FE916BBD4E100C2F881 /* NSData+Base64.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E1C7FE516BBD4E100C2F881 /* NSData+Base64.h */; };
+		4E1C7FEA16BBD4E100C2F881 /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E1C7FE616BBD4E100C2F881 /* NSData+Base64.m */; };
+		4E1C7FEB16BBD4E100C2F881 /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E1C7FE616BBD4E100C2F881 /* NSData+Base64.m */; };
 		CD0C658B15ECF981006DE7F3 /* SuperInterpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = CD0C658915ECF981006DE7F3 /* SuperInterpreter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CD0C658C15ECF981006DE7F3 /* SuperInterpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = CD0C658915ECF981006DE7F3 /* SuperInterpreter.h */; };
 		CD0C658D15ECF981006DE7F3 /* SuperInterpreter.m in Sources */ = {isa = PBXBuildFile; fileRef = CD0C658A15ECF981006DE7F3 /* SuperInterpreter.m */; };
@@ -281,6 +285,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4E1C7FE516BBD4E100C2F881 /* NSData+Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Base64.h"; sourceTree = "<group>"; };
+		4E1C7FE616BBD4E100C2F881 /* NSData+Base64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Base64.m"; sourceTree = "<group>"; };
 		CD0C658915ECF981006DE7F3 /* SuperInterpreter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SuperInterpreter.h; sourceTree = "<group>"; };
 		CD0C658A15ECF981006DE7F3 /* SuperInterpreter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SuperInterpreter.m; sourceTree = "<group>"; };
 		CD0C659015ECFADF006DE7F3 /* SuperNetworkMessageTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SuperNetworkMessageTypes.h; sourceTree = "<group>"; };
@@ -558,6 +564,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4E1C7FE416BBD4E100C2F881 /* NSData-Base64 */ = {
+			isa = PBXGroup;
+			children = (
+				4E1C7FE516BBD4E100C2F881 /* NSData+Base64.h */,
+				4E1C7FE616BBD4E100C2F881 /* NSData+Base64.m */,
+			);
+			name = "NSData-Base64";
+			path = "../../SuperDebug/Super Debug/Libraries/NSData-Base64";
+			sourceTree = "<group>";
+		};
 		CD0D94E215B871D6003A0D8B /* F-Script */ = {
 			isa = PBXGroup;
 			children = (
@@ -869,6 +885,7 @@
 				CD0D94E215B871D6003A0D8B /* F-Script */,
 				CDF1AAAA15A8D7760038EAB7 /* SuperDBCore.h */,
 				CDCD46AC15A8DD390070D05C /* Network layer */,
+				4E1C7FE416BBD4E100C2F881 /* NSData-Base64 */,
 				CDF1AAA815A8D7760038EAB7 /* Supporting Files */,
 			);
 			path = SuperDBCore;
@@ -1044,6 +1061,7 @@
 				CD6FF28915EFC2B100E63391 /* Space.h in Headers */,
 				CD6BF728161FD99D00B8FBB0 /* SuperJSTP.h in Headers */,
 				CDDC9F8916224697006883CE /* Geometry.h in Headers */,
+				4E1C7FE816BBD4E100C2F881 /* NSData+Base64.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1060,6 +1078,7 @@
 				CD0D94DD15B84C21003A0D8B /* SuperNetworkMessage.h in Headers */,
 				CD0C658C15ECF981006DE7F3 /* SuperInterpreter.h in Headers */,
 				CD0C659215ECFADF006DE7F3 /* SuperNetworkMessageTypes.h in Headers */,
+				4E1C7FE916BBD4E100C2F881 /* NSData+Base64.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1252,6 +1271,7 @@
 				CD40C80C15F0ECCB002E3A58 /* SuperInterpreterObjectBrowser.m in Sources */,
 				CD6BF729161FD99D00B8FBB0 /* SuperJSTP.m in Sources */,
 				CDDC9F8A16224697006883CE /* Geometry.m in Sources */,
+				4E1C7FEA16BBD4E100C2F881 /* NSData+Base64.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1266,6 +1286,7 @@
 				CD0D94D915B84683003A0D8B /* SuperInterpreterClient.m in Sources */,
 				CD0D94DF15B84C21003A0D8B /* SuperNetworkMessage.m in Sources */,
 				CD0C658E15ECF981006DE7F3 /* SuperInterpreter.m in Sources */,
+				4E1C7FEB16BBD4E100C2F881 /* NSData+Base64.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SuperDBCore/SuperDBCore.xcodeproj/project.pbxproj
+++ b/SuperDBCore/SuperDBCore.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		4E1C7FE916BBD4E100C2F881 /* NSData+Base64.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E1C7FE516BBD4E100C2F881 /* NSData+Base64.h */; };
 		4E1C7FEA16BBD4E100C2F881 /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E1C7FE616BBD4E100C2F881 /* NSData+Base64.m */; };
 		4E1C7FEB16BBD4E100C2F881 /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E1C7FE616BBD4E100C2F881 /* NSData+Base64.m */; };
+		4E5E4B9716E5CFC7004210DA /* UIView+SDBScreenshot.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E5E4B9516E5CFC7004210DA /* UIView+SDBScreenshot.h */; };
+		4E5E4B9816E5CFC7004210DA /* UIView+SDBScreenshot.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E5E4B9616E5CFC7004210DA /* UIView+SDBScreenshot.m */; };
 		CD0C658B15ECF981006DE7F3 /* SuperInterpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = CD0C658915ECF981006DE7F3 /* SuperInterpreter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CD0C658C15ECF981006DE7F3 /* SuperInterpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = CD0C658915ECF981006DE7F3 /* SuperInterpreter.h */; };
 		CD0C658D15ECF981006DE7F3 /* SuperInterpreter.m in Sources */ = {isa = PBXBuildFile; fileRef = CD0C658A15ECF981006DE7F3 /* SuperInterpreter.m */; };
@@ -287,6 +289,8 @@
 /* Begin PBXFileReference section */
 		4E1C7FE516BBD4E100C2F881 /* NSData+Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Base64.h"; sourceTree = "<group>"; };
 		4E1C7FE616BBD4E100C2F881 /* NSData+Base64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Base64.m"; sourceTree = "<group>"; };
+		4E5E4B9516E5CFC7004210DA /* UIView+SDBScreenshot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+SDBScreenshot.h"; sourceTree = "<group>"; };
+		4E5E4B9616E5CFC7004210DA /* UIView+SDBScreenshot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+SDBScreenshot.m"; sourceTree = "<group>"; };
 		CD0C658915ECF981006DE7F3 /* SuperInterpreter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SuperInterpreter.h; sourceTree = "<group>"; };
 		CD0C658A15ECF981006DE7F3 /* SuperInterpreter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SuperInterpreter.m; sourceTree = "<group>"; };
 		CD0C659015ECFADF006DE7F3 /* SuperNetworkMessageTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SuperNetworkMessageTypes.h; sourceTree = "<group>"; };
@@ -820,6 +824,8 @@
 				CD40C80A15F0ECCB002E3A58 /* SuperInterpreterObjectBrowser.m */,
 				CDDC9F8716224697006883CE /* Geometry.h */,
 				CDDC9F8816224697006883CE /* Geometry.m */,
+				4E5E4B9516E5CFC7004210DA /* UIView+SDBScreenshot.h */,
+				4E5E4B9616E5CFC7004210DA /* UIView+SDBScreenshot.m */,
 			);
 			name = SuperInterpreter;
 			sourceTree = "<group>";
@@ -1062,6 +1068,7 @@
 				CD6BF728161FD99D00B8FBB0 /* SuperJSTP.h in Headers */,
 				CDDC9F8916224697006883CE /* Geometry.h in Headers */,
 				4E1C7FE816BBD4E100C2F881 /* NSData+Base64.h in Headers */,
+				4E5E4B9716E5CFC7004210DA /* UIView+SDBScreenshot.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1272,6 +1279,7 @@
 				CD6BF729161FD99D00B8FBB0 /* SuperJSTP.m in Sources */,
 				CDDC9F8A16224697006883CE /* Geometry.m in Sources */,
 				4E1C7FEA16BBD4E100C2F881 /* NSData+Base64.m in Sources */,
+				4E5E4B9816E5CFC7004210DA /* UIView+SDBScreenshot.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SuperDBCore/SuperDBCore/SuperDBCore.h
+++ b/SuperDBCore/SuperDBCore/SuperDBCore.h
@@ -38,6 +38,10 @@
 #import "SuperInterpreterClient.h"
 #import "SuperNetworkMessage.h"
 
+#if TARGET_OS_IPHONE
+#    import "UIView+SDBScreenshot.h"
+#endif
+
 #import "FSInterpreter.h"
 #import "FSInterpreterResult.h"
 #import "FSMiscTools.h"

--- a/SuperDBCore/SuperDBCore/SuperInterpreter.m
+++ b/SuperDBCore/SuperDBCore/SuperInterpreter.m
@@ -188,8 +188,8 @@
 	}];
 	
 	[self addRequestHandlerForResource:kSuperNetworkMessageResourceImageData
-                        requestHandler:^SuperNetworkMessage *(SuperNetworkMessage *request)
-     {
+                        requestHandler:^SuperNetworkMessage *(SuperNetworkMessage *request) {
+                            
          NSMutableDictionary *body = [@{} mutableCopy];
          NSString *input = [[request body] objectForKey:kSuperNetworkMessageBodyInputKey];
          
@@ -202,14 +202,12 @@
              
 #if TARGET_OS_IPHONE
              id object = [result result];
-             if ([object isKindOfClass:[UIImage class]])
-             {
+             if ([object isKindOfClass:[UIImage class]]) {
+                 
                  NSData *imgRep = UIImageJPEGRepresentation(object, 0.8);
                  [body setObject:kSuperNetworkMessageBodyStatusOK forKey:kSuperNetworkMessageBodyStatusKey];
                  [body setObject:[imgRep base64EncodedString] forKey:kSuperNetworkMessageBodyOutputKey];
-             }
-             else
-             {
+             } else {
                  NSString *noImageError = @"The result is not an image.";
                  [body setObject:kSuperNetworkMessageBodyStatusError forKey:kSuperNetworkMessageBodyStatusKey];
                  [body setObject:noImageError forKey:kSuperNetworkMessageBodyErrorMessageKey];

--- a/SuperDBCore/SuperDBCore/SuperNetworkMessage.m
+++ b/SuperDBCore/SuperDBCore/SuperNetworkMessage.m
@@ -57,6 +57,7 @@ NSString *kSuperNetworkMessageResourcePropertyList = @"property_list";
 NSString *kSuperNetworkMessageResourceMethodList = @"method_list";
 NSString *kSuperNetworkMessageResourceUpdateCurrentSelfPointer = @"update_current_self_pointer";
 NSString *kSuperNetworkMessageResourceDeviceLoggingSettings = @"device_logging";
+NSString *kSuperNetworkMessageResourceImageData = @"image_data";
 
 
 @interface SuperNetworkMessage ()
@@ -73,7 +74,8 @@ NSString *kSuperNetworkMessageResourceDeviceLoggingSettings = @"device_logging";
 						@".classes" : kSuperNetworkMessageResourceClassList,
 						@".methods" : kSuperNetworkMessageResourceMethodList,
 						@".self" : kSuperNetworkMessageResourceUpdateCurrentSelfPointer,
-						@".logging" : kSuperNetworkMessageResourceDeviceLoggingSettings};
+						@".logging" : kSuperNetworkMessageResourceDeviceLoggingSettings,
+    					@".image" : kSuperNetworkMessageResourceImageData};
 }
 
 

--- a/SuperDBCore/SuperDBCore/SuperNetworkMessageTypes.h
+++ b/SuperDBCore/SuperDBCore/SuperNetworkMessageTypes.h
@@ -60,6 +60,7 @@ extern NSString *kSuperNetworkMessageResourcePropertyList;
 extern NSString *kSuperNetworkMessageResourceMethodList;
 extern NSString *kSuperNetworkMessageResourceUpdateCurrentSelfPointer;
 extern NSString *kSuperNetworkMessageResourceDeviceLoggingSettings;
+extern NSString *kSuperNetworkMessageResourceImageData;
 
 #pragma mark - JSTP defines
 #define kJSTPHeaderTag 6000

--- a/SuperDBCore/SuperDBCore/UIView+SDBScreenshot.h
+++ b/SuperDBCore/SuperDBCore/UIView+SDBScreenshot.h
@@ -1,0 +1,18 @@
+//
+//  UIView+SDBScreenshot.h
+//  SuperDBCore
+//
+//  Created by Mathieu Godart on 05/03/13.
+//  Copyright (c) 2013 Super Debugger. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIView (SDBScreenshot)
+
+// Generate an image of the receiver appearance.
+// TODO: Improve the target resolution of the generated photo. See that page, to do so:
+// http://stackoverflow.com/questions/2500915/how-to-create-an-image-from-a-uiview-uiscrollview
+- (UIImage *)generateImage;
+
+@end

--- a/SuperDBCore/SuperDBCore/UIView+SDBScreenshot.m
+++ b/SuperDBCore/SuperDBCore/UIView+SDBScreenshot.m
@@ -1,0 +1,29 @@
+//
+//  UIView+SDBScreenshot.m
+//  SuperDBCore
+//
+//  Created by Mathieu Godart on 05/03/13.
+//  Copyright (c) 2013 Super Debugger. All rights reserved.
+//
+
+#import "UIView+SDBScreenshot.h"
+#import <QuartzCore/QuartzCore.h>
+
+@implementation UIView (SDBScreenshot)
+
+// Generate an image of the receiver appearance.
+// TODO: Improve the target resolution of the generated photo. See that page, to do so:
+// http://stackoverflow.com/questions/2500915/how-to-create-an-image-from-a-uiview-uiscrollview
+- (UIImage *)generateImage
+{
+    UIGraphicsBeginImageContext(self.frame.size);
+    CGContextRef generatingContext = UIGraphicsGetCurrentContext();
+    
+    [self.layer renderInContext:generatingContext];
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    return newImage;
+}
+
+@end

--- a/SuperDebug/Super Debug.xcodeproj/project.pbxproj
+++ b/SuperDebug/Super Debug.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4E1C7FF116BBD6B800C2F881 /* NSData+Base64.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E1C7FEF16BBD6B800C2F881 /* NSData+Base64.m */; };
+		4E1C7FF216BBD6B800C2F881 /* NSData+Base64.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 4E1C7FF016BBD6B800C2F881 /* NSData+Base64.podspec */; };
 		CD0D94D215B84482003A0D8B /* SuperDebugAreaWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = CD0D94D015B84482003A0D8B /* SuperDebugAreaWindowController.m */; };
 		CD0D94D315B84482003A0D8B /* SuperDebugAreaWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CD0D94D115B84482003A0D8B /* SuperDebugAreaWindowController.xib */; };
 		CD0D94E115B859C4003A0D8B /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD0D94E015B859C4003A0D8B /* Security.framework */; };
@@ -51,6 +53,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4E1C7FEE16BBD6B800C2F881 /* NSData+Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Base64.h"; sourceTree = "<group>"; };
+		4E1C7FEF16BBD6B800C2F881 /* NSData+Base64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Base64.m"; sourceTree = "<group>"; };
+		4E1C7FF016BBD6B800C2F881 /* NSData+Base64.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "NSData+Base64.podspec"; sourceTree = "<group>"; };
 		CD0D94CF15B84482003A0D8B /* SuperDebugAreaWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SuperDebugAreaWindowController.h; sourceTree = "<group>"; };
 		CD0D94D015B84482003A0D8B /* SuperDebugAreaWindowController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SuperDebugAreaWindowController.m; sourceTree = "<group>"; };
 		CD0D94D115B84482003A0D8B /* SuperDebugAreaWindowController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SuperDebugAreaWindowController.xib; sourceTree = "<group>"; };
@@ -112,6 +117,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4E1C7FED16BBD6B800C2F881 /* NSData-Base64 */ = {
+			isa = PBXGroup;
+			children = (
+				4E1C7FEE16BBD6B800C2F881 /* NSData+Base64.h */,
+				4E1C7FEF16BBD6B800C2F881 /* NSData+Base64.m */,
+				4E1C7FF016BBD6B800C2F881 /* NSData+Base64.podspec */,
+			);
+			path = "NSData-Base64";
+			sourceTree = "<group>";
+		};
 		CD0D975915B8869B003A0D8B /* Shell */ = {
 			isa = PBXGroup;
 			children = (
@@ -237,6 +252,7 @@
 		CDDC9F8C16224CFC006883CE /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				4E1C7FED16BBD6B800C2F881 /* NSData-Base64 */,
 				CD7353BE166FF624002D52D3 /* ParseKit.xcodeproj */,
 				CDA3FFBD166D07EC007C892F /* Shell */,
 			);
@@ -325,6 +341,7 @@
 				CDD65BD415A8D07800505C37 /* SuperDeviceSelectionWindowController.xib in Resources */,
 				CD0D94D315B84482003A0D8B /* SuperDebugAreaWindowController.xib in Resources */,
 				CD360F6F1638696400617446 /* JBSuggestionsTableView.xib in Resources */,
+				4E1C7FF216BBD6B800C2F881 /* NSData+Base64.podspec in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -349,6 +366,7 @@
 				CDA3FFC6166D0884007C892F /* JBShellContainerView.m in Sources */,
 				CDA3FFC7166D0884007C892F /* JBShellView.m in Sources */,
 				CDA3FFCA166D0899007C892F /* JBTextEditorProcessor.m in Sources */,
+				4E1C7FF116BBD6B800C2F881 /* NSData+Base64.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SuperDebug/Super Debug/Libraries/NSData-Base64/NSData+Base64.h
+++ b/SuperDebug/Super Debug/Libraries/NSData-Base64/NSData+Base64.h
@@ -1,0 +1,45 @@
+//
+//  NSData+Base64.h
+//  base64
+//
+//  Created by Matt Gallagher on 2009/06/03.
+//  Copyright 2009 Matt Gallagher. All rights reserved.
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty. In no event will the authors be held liable for any damages
+//  arising from the use of this software. Permission is granted to anyone to
+//  use this software for any purpose, including commercial applications, and to
+//  alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//  3. This notice may not be removed or altered from any source
+//     distribution.
+//
+
+#import <Foundation/Foundation.h>
+
+void *NewBase64Decode(
+	const char *inputBuffer,
+	size_t length,
+	size_t *outputLength);
+
+char *NewBase64Encode(
+	const void *inputBuffer,
+	size_t length,
+	bool separateLines,
+	size_t *outputLength);
+
+@interface NSData (Base64)
+
++ (NSData *)dataFromBase64String:(NSString *)aString;
+- (NSString *)base64EncodedString;
+
+// added by Hiroshi Hashiguchi
+- (NSString *)base64EncodedStringWithSeparateLines:(BOOL)separateLines;
+
+@end

--- a/SuperDebug/Super Debug/Libraries/NSData-Base64/NSData+Base64.m
+++ b/SuperDebug/Super Debug/Libraries/NSData-Base64/NSData+Base64.m
@@ -1,0 +1,329 @@
+//
+//  NSData+Base64.m
+//  base64
+//
+//  Created by Matt Gallagher on 2009/06/03.
+//  Copyright 2009 Matt Gallagher. All rights reserved.
+//
+//  This software is provided 'as-is', without any express or implied
+//  warranty. In no event will the authors be held liable for any damages
+//  arising from the use of this software. Permission is granted to anyone to
+//  use this software for any purpose, including commercial applications, and to
+//  alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not
+//     claim that you wrote the original software. If you use this software
+//     in a product, an acknowledgment in the product documentation would be
+//     appreciated but is not required.
+//  2. Altered source versions must be plainly marked as such, and must not be
+//     misrepresented as being the original software.
+//  3. This notice may not be removed or altered from any source
+//     distribution.
+//
+
+#import "NSData+Base64.h"
+
+//
+// Mapping from 6 bit pattern to ASCII character.
+//
+static unsigned char base64EncodeLookup[65] =
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+//
+// Definition for "masked-out" areas of the base64DecodeLookup mapping
+//
+#define xx 65
+
+//
+// Mapping from ASCII character to 6 bit pattern.
+//
+static unsigned char base64DecodeLookup[256] =
+{
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 62, xx, xx, xx, 63, 
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, xx, xx, xx, xx, xx, xx, 
+    xx,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 
+    15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, xx, xx, xx, xx, xx, 
+    xx, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+    xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, 
+};
+
+//
+// Fundamental sizes of the binary and base64 encode/decode units in bytes
+//
+#define BINARY_UNIT_SIZE 3
+#define BASE64_UNIT_SIZE 4
+
+//
+// NewBase64Decode
+//
+// Decodes the base64 ASCII string in the inputBuffer to a newly malloced
+// output buffer.
+//
+//  inputBuffer - the source ASCII string for the decode
+//	length - the length of the string or -1 (to specify strlen should be used)
+//	outputLength - if not-NULL, on output will contain the decoded length
+//
+// returns the decoded buffer. Must be free'd by caller. Length is given by
+//	outputLength.
+//
+void *NewBase64Decode(
+	const char *inputBuffer,
+	size_t length,
+	size_t *outputLength)
+{
+	if (length == -1)
+	{
+		length = strlen(inputBuffer);
+	}
+	
+	size_t outputBufferSize =
+		((length+BASE64_UNIT_SIZE-1) / BASE64_UNIT_SIZE) * BINARY_UNIT_SIZE;
+	unsigned char *outputBuffer = (unsigned char *)malloc(outputBufferSize);
+	
+	size_t i = 0;
+	size_t j = 0;
+	while (i < length)
+	{
+		//
+		// Accumulate 4 valid characters (ignore everything else)
+		//
+		unsigned char accumulated[BASE64_UNIT_SIZE];
+		size_t accumulateIndex = 0;
+		while (i < length)
+		{
+			unsigned char decode = base64DecodeLookup[inputBuffer[i++]];
+			if (decode != xx)
+			{
+				accumulated[accumulateIndex] = decode;
+				accumulateIndex++;
+				
+				if (accumulateIndex == BASE64_UNIT_SIZE)
+				{
+					break;
+				}
+			}
+		}
+		
+		//
+		// Store the 6 bits from each of the 4 characters as 3 bytes
+		//
+		// (Uses improved bounds checking suggested by Alexandre Colucci)
+		//
+		if(accumulateIndex >= 2)  
+			outputBuffer[j] = (accumulated[0] << 2) | (accumulated[1] >> 4);  
+		if(accumulateIndex >= 3)  
+			outputBuffer[j + 1] = (accumulated[1] << 4) | (accumulated[2] >> 2);  
+		if(accumulateIndex >= 4)  
+			outputBuffer[j + 2] = (accumulated[2] << 6) | accumulated[3];
+		j += accumulateIndex - 1;
+	}
+	
+	if (outputLength)
+	{
+		*outputLength = j;
+	}
+	return outputBuffer;
+}
+
+//
+// NewBase64Encode
+//
+// Encodes the arbitrary data in the inputBuffer as base64 into a newly malloced
+// output buffer.
+//
+//  inputBuffer - the source data for the encode
+//	length - the length of the input in bytes
+//  separateLines - if zero, no CR/LF characters will be added. Otherwise
+//		a CR/LF pair will be added every 64 encoded chars.
+//	outputLength - if not-NULL, on output will contain the encoded length
+//		(not including terminating 0 char)
+//
+// returns the encoded buffer. Must be free'd by caller. Length is given by
+//	outputLength.
+//
+char *NewBase64Encode(
+	const void *buffer,
+	size_t length,
+	bool separateLines,
+	size_t *outputLength)
+{
+	const unsigned char *inputBuffer = (const unsigned char *)buffer;
+	
+	#define MAX_NUM_PADDING_CHARS 2
+	#define OUTPUT_LINE_LENGTH 64
+	#define INPUT_LINE_LENGTH ((OUTPUT_LINE_LENGTH / BASE64_UNIT_SIZE) * BINARY_UNIT_SIZE)
+	#define CR_LF_SIZE 2
+	
+	//
+	// Byte accurate calculation of final buffer size
+	//
+	size_t outputBufferSize =
+			((length / BINARY_UNIT_SIZE)
+				+ ((length % BINARY_UNIT_SIZE) ? 1 : 0))
+					* BASE64_UNIT_SIZE;
+	if (separateLines)
+	{
+		outputBufferSize +=
+			(outputBufferSize / OUTPUT_LINE_LENGTH) * CR_LF_SIZE;
+	}
+	
+	//
+	// Include space for a terminating zero
+	//
+	outputBufferSize += 1;
+
+	//
+	// Allocate the output buffer
+	//
+	char *outputBuffer = (char *)malloc(outputBufferSize);
+	if (!outputBuffer)
+	{
+		return NULL;
+	}
+
+	size_t i = 0;
+	size_t j = 0;
+	const size_t lineLength = separateLines ? INPUT_LINE_LENGTH : length;
+	size_t lineEnd = lineLength;
+	
+	while (true)
+	{
+		if (lineEnd > length)
+		{
+			lineEnd = length;
+		}
+
+		for (; i + BINARY_UNIT_SIZE - 1 < lineEnd; i += BINARY_UNIT_SIZE)
+		{
+			//
+			// Inner loop: turn 48 bytes into 64 base64 characters
+			//
+			outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i] & 0xFC) >> 2];
+			outputBuffer[j++] = base64EncodeLookup[((inputBuffer[i] & 0x03) << 4)
+				| ((inputBuffer[i + 1] & 0xF0) >> 4)];
+			outputBuffer[j++] = base64EncodeLookup[((inputBuffer[i + 1] & 0x0F) << 2)
+				| ((inputBuffer[i + 2] & 0xC0) >> 6)];
+			outputBuffer[j++] = base64EncodeLookup[inputBuffer[i + 2] & 0x3F];
+		}
+		
+		if (lineEnd == length)
+		{
+			break;
+		}
+		
+		//
+		// Add the newline
+		//
+		outputBuffer[j++] = '\r';
+		outputBuffer[j++] = '\n';
+		lineEnd += lineLength;
+	}
+	
+	if (i + 1 < length)
+	{
+		//
+		// Handle the single '=' case
+		//
+		outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i] & 0xFC) >> 2];
+		outputBuffer[j++] = base64EncodeLookup[((inputBuffer[i] & 0x03) << 4)
+			| ((inputBuffer[i + 1] & 0xF0) >> 4)];
+		outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i + 1] & 0x0F) << 2];
+		outputBuffer[j++] =	'=';
+	}
+	else if (i < length)
+	{
+		//
+		// Handle the double '=' case
+		//
+		outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i] & 0xFC) >> 2];
+		outputBuffer[j++] = base64EncodeLookup[(inputBuffer[i] & 0x03) << 4];
+		outputBuffer[j++] = '=';
+		outputBuffer[j++] = '=';
+	}
+	outputBuffer[j] = 0;
+	
+	//
+	// Set the output length and return the buffer
+	//
+	if (outputLength)
+	{
+		*outputLength = j;
+	}
+	return outputBuffer;
+}
+
+@implementation NSData (Base64)
+
+//
+// dataFromBase64String:
+//
+// Creates an NSData object containing the base64 decoded representation of
+// the base64 string 'aString'
+//
+// Parameters:
+//    aString - the base64 string to decode
+//
+// returns the autoreleased NSData representation of the base64 string
+//
++ (NSData *)dataFromBase64String:(NSString *)aString
+{
+	NSData *data = [aString dataUsingEncoding:NSASCIIStringEncoding];
+	size_t outputLength;
+	void *outputBuffer = NewBase64Decode([data bytes], [data length], &outputLength);
+	NSData *result = [NSData dataWithBytes:outputBuffer length:outputLength];
+	free(outputBuffer);
+	return result;
+}
+
+//
+// base64EncodedString
+//
+// Creates an NSString object that contains the base 64 encoding of the
+// receiver's data. Lines are broken at 64 characters long.
+//
+// returns an autoreleased NSString being the base 64 representation of the
+//	receiver.
+//
+- (NSString *)base64EncodedString
+{
+	size_t outputLength;
+	char *outputBuffer =
+		NewBase64Encode([self bytes], [self length], true, &outputLength);
+	
+	NSString *result =
+		[[NSString alloc]
+			initWithBytes:outputBuffer
+			length:outputLength
+			encoding:NSASCIIStringEncoding];
+	free(outputBuffer);
+	return result;
+}
+
+// added by Hiroshi Hashiguchi
+- (NSString *)base64EncodedStringWithSeparateLines:(BOOL)separateLines
+{
+	size_t outputLength;
+	char *outputBuffer =
+    NewBase64Encode([self bytes], [self length], separateLines, &outputLength);
+	
+	NSString *result =
+    [[NSString alloc]
+      initWithBytes:outputBuffer
+      length:outputLength
+      encoding:NSASCIIStringEncoding];
+	free(outputBuffer);
+	return result;
+}
+
+
+@end

--- a/SuperDebug/Super Debug/Libraries/NSData-Base64/NSData+Base64.podspec
+++ b/SuperDebug/Super Debug/Libraries/NSData-Base64/NSData+Base64.podspec
@@ -1,0 +1,9 @@
+Pod::Spec.new do |s|
+  s.name     = 'NSData+Base64'
+  s.version  = '1.0.0'
+  s.summary  = 'Base64 for NSData'
+  s.homepage = ''
+  s.author   = { 'Matt Gallagher' => '' }
+  s.source   = { :git => 'git://github.com/l4u/NSData-Base64.git', :tag => '1.0.0' }
+  s.source_files = '*.{h,m}'
+end

--- a/SuperDebug/Super Debug/SuperDebugAreaWindowController.m
+++ b/SuperDebug/Super Debug/SuperDebugAreaWindowController.m
@@ -89,16 +89,13 @@
                     // TODO: move this hardcoded command to a header file,
                     // common with the super interpreter.
                     // Ask Jason about that.
-                    if ([choppedCommand isEqualToString:@".image"])
-                    {
+                    if ([choppedCommand isEqualToString:@".image"]) {
                         NSString *output = [[response body] objectForKey:kSuperNetworkMessageBodyOutputKey];
                         NSString *bodyDataRep = output;
                         NSData *bodyData = [NSData dataFromBase64String:bodyDataRep];
                         weakSelf.imageViewer.image = [[NSImage alloc] initWithData:bodyData];
                         [[weakSelf.imageViewer window] makeKeyAndOrderFront:weakSelf];
-                    }
-                    else
-                    {
+                    } else {
                         NSString *output = [[response body] objectForKey:kSuperNetworkMessageBodyOutputKey];
                         [sender appendOutputWithNewlines:[output description]];
 //                        [weakSelf.suggestionWindowController beginForParentTextView:sender];

--- a/SuperDebug/Super Debug/SuperDebugAreaWindowController.m
+++ b/SuperDebug/Super Debug/SuperDebugAreaWindowController.m
@@ -81,8 +81,12 @@
 			NSString *choppedInput = [self longInputFromCommand:input];
 			NSString *choppedCommand = [self commandFromCommand:input];
 			
-            __weak __typeof__(self) weakSelf = self;
-
+            // FIXME: the pointer to self should be weak here. But, for some reason, we "cannot
+            // form weak reference to instance of class SuperDebugAreaWindowController" according
+            // to the runtime… Needs to be investigated.
+//            __weak __typeof__(self) weakSelf = self;
+            __typeof__(self) weakSelf = self;
+            
 			[self.networkClient requestWithCommand:choppedCommand input:choppedInput responseHandler:^(SuperNetworkMessage *response) {
 				if ([[[response body] objectForKey:kSuperNetworkMessageBodyStatusKey] isEqualToString:kSuperNetworkMessageBodyStatusOK]) {
                     

--- a/SuperDebug/Super Debug/SuperDebugAreaWindowController.xib
+++ b/SuperDebug/Super Debug/SuperDebugAreaWindowController.xib
@@ -2,16 +2,19 @@
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1080</int>
-		<string key="IBDocument.SystemVersion">12C54</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2840</string>
+		<string key="IBDocument.SystemVersion">12C60</string>
+		<string key="IBDocument.InterfaceBuilderVersion">2844</string>
 		<string key="IBDocument.AppKitVersion">1187.34</string>
 		<string key="IBDocument.HIToolboxVersion">625.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">2840</string>
+			<string key="NS.object.0">2844</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
+			<string>IBNSLayoutConstraint</string>
 			<string>NSCustomObject</string>
+			<string>NSImageCell</string>
+			<string>NSImageView</string>
 			<string>NSView</string>
 			<string>NSWindowTemplate</string>
 		</array>
@@ -48,9 +51,61 @@
 					<reference key="NSSuperview"/>
 					<reference key="NSWindow"/>
 				</object>
-				<string key="NSScreenRect">{{0, 0}, {1440, 878}}</string>
+				<string key="NSScreenRect">{{0, 0}, {2560, 1418}}</string>
 				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<int key="NSWindowCollectionBehavior">128</int>
+				<bool key="NSWindowIsRestorable">YES</bool>
+			</object>
+			<object class="NSWindowTemplate" id="808128937">
+				<int key="NSWindowStyleMask">15</int>
+				<int key="NSWindowBacking">2</int>
+				<string key="NSWindowRect">{{109, 138}, {300, 300}}</string>
+				<int key="NSWTFlags">611845120</int>
+				<string key="NSWindowTitle">Image Viewer</string>
+				<string key="NSWindowClass">NSWindow</string>
+				<nil key="NSViewClass"/>
+				<nil key="NSUserInterfaceItemIdentifier"/>
+				<object class="NSView" key="NSWindowView" id="532889351">
+					<reference key="NSNextResponder"/>
+					<int key="NSvFlags">256</int>
+					<array class="NSMutableArray" key="NSSubviews">
+						<object class="NSImageView" id="137660029">
+							<reference key="NSNextResponder" ref="532889351"/>
+							<int key="NSvFlags">268</int>
+							<set class="NSMutableSet" key="NSDragTypes">
+								<string>Apple PDF pasteboard type</string>
+								<string>Apple PICT pasteboard type</string>
+								<string>Apple PNG pasteboard type</string>
+								<string>NSFilenamesPboardType</string>
+								<string>NeXT Encapsulated PostScript v1.2 pasteboard type</string>
+								<string>NeXT TIFF v4.0 pasteboard type</string>
+							</set>
+							<string key="NSFrame">{{-3, -3}, {306, 306}}</string>
+							<reference key="NSSuperview" ref="532889351"/>
+							<reference key="NSWindow"/>
+							<string key="NSReuseIdentifierKey">_NS:9</string>
+							<bool key="NSEnabled">YES</bool>
+							<object class="NSImageCell" key="NSCell" id="317218839">
+								<int key="NSCellFlags">134217728</int>
+								<int key="NSCellFlags2">33554432</int>
+								<string key="NSCellIdentifier">_NS:9</string>
+								<int key="NSAlign">0</int>
+								<int key="NSScale">3</int>
+								<int key="NSStyle">1</int>
+								<bool key="NSAnimates">YES</bool>
+							</object>
+							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
+							<bool key="NSEditable">YES</bool>
+						</object>
+					</array>
+					<string key="NSFrameSize">{300, 300}</string>
+					<reference key="NSSuperview"/>
+					<reference key="NSWindow"/>
+					<reference key="NSNextKeyView" ref="137660029"/>
+					<string key="NSReuseIdentifierKey">_NS:20</string>
+				</object>
+				<string key="NSScreenRect">{{0, 0}, {2560, 1418}}</string>
+				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
 				<bool key="NSWindowIsRestorable">YES</bool>
 			</object>
 		</array>
@@ -63,6 +118,14 @@
 						<reference key="destination" ref="1005"/>
 					</object>
 					<int key="connectionID">3</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBOutletConnection" key="connection">
+						<string key="label">imageViewer</string>
+						<reference key="source" ref="1001"/>
+						<reference key="destination" ref="137660029"/>
+					</object>
+					<int key="connectionID">50</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBOutletConnection" key="connection">
@@ -110,7 +173,121 @@
 					<object class="IBObjectRecord">
 						<int key="objectID">2</int>
 						<reference key="object" ref="1006"/>
+						<array class="NSMutableArray" key="children"/>
 						<reference key="parent" ref="1005"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">17</int>
+						<reference key="object" ref="808128937"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="532889351"/>
+						</array>
+						<reference key="parent" ref="0"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">18</int>
+						<reference key="object" ref="532889351"/>
+						<array class="NSMutableArray" key="children">
+							<object class="IBNSLayoutConstraint" id="288359991">
+								<reference key="firstItem" ref="137660029"/>
+								<int key="firstAttribute">4</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="532889351"/>
+								<int key="secondAttribute">4</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="532889351"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="948234383">
+								<reference key="firstItem" ref="137660029"/>
+								<int key="firstAttribute">6</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="532889351"/>
+								<int key="secondAttribute">6</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="532889351"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="575488021">
+								<reference key="firstItem" ref="137660029"/>
+								<int key="firstAttribute">5</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="532889351"/>
+								<int key="secondAttribute">5</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="532889351"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="98439221">
+								<reference key="firstItem" ref="137660029"/>
+								<int key="firstAttribute">3</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="532889351"/>
+								<int key="secondAttribute">3</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="532889351"/>
+								<int key="scoringType">8</int>
+								<float key="scoringTypeFloat">29</float>
+								<int key="contentType">3</int>
+							</object>
+							<reference ref="137660029"/>
+						</array>
+						<reference key="parent" ref="808128937"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">19</int>
+						<reference key="object" ref="137660029"/>
+						<array class="NSMutableArray" key="children">
+							<reference ref="317218839"/>
+						</array>
+						<reference key="parent" ref="532889351"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">20</int>
+						<reference key="object" ref="317218839"/>
+						<reference key="parent" ref="137660029"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">45</int>
+						<reference key="object" ref="98439221"/>
+						<reference key="parent" ref="532889351"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">46</int>
+						<reference key="object" ref="575488021"/>
+						<reference key="parent" ref="532889351"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">47</int>
+						<reference key="object" ref="948234383"/>
+						<reference key="parent" ref="532889351"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">48</int>
+						<reference key="object" ref="288359991"/>
+						<reference key="parent" ref="532889351"/>
 					</object>
 				</array>
 			</object>
@@ -121,19 +298,54 @@
 				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="1.IBWindowTemplateEditedContentRect">{{357, 418}, {480, 270}}</string>
 				<integer value="1" key="1.NSWindowTemplate.visibleAtLaunch"/>
+				<string key="17.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<boolean value="NO" key="17.NSWindowTemplate.visibleAtLaunch"/>
+				<array class="NSMutableArray" key="18.IBNSViewMetadataConstraints">
+					<reference ref="98439221"/>
+					<reference ref="575488021"/>
+					<reference ref="948234383"/>
+					<reference ref="288359991"/>
+				</array>
+				<string key="18.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<boolean value="NO" key="19.IBNSViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
+				<string key="19.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 				<string key="2.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="20.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="45.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="46.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="47.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
+				<string key="48.IBPluginDependency">com.apple.InterfaceBuilder.CocoaPlugin</string>
 			</dictionary>
 			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">4</int>
+			<int key="maxID">50</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
 				<object class="IBPartialClassDescription">
+					<string key="className">NSLayoutConstraint</string>
+					<string key="superclassName">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/NSLayoutConstraint.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
 					<string key="className">SuperDebugAreaWindowController</string>
 					<string key="superclassName">NSWindowController</string>
+					<object class="NSMutableDictionary" key="outlets">
+						<string key="NS.key.0">imageViewer</string>
+						<string key="NS.object.0">NSImageView</string>
+					</object>
+					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<string key="NS.key.0">imageViewer</string>
+						<object class="IBToOneOutletInfo" key="NS.object.0">
+							<string key="name">imageViewer</string>
+							<string key="candidateClassName">NSImageView</string>
+						</object>
+					</object>
 					<object class="IBClassDescriptionSource" key="sourceIdentifier">
 						<string key="majorKey">IBProjectSource</string>
 						<string key="minorKey">./Classes/SuperDebugAreaWindowController.h</string>

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,8 @@ If you'd like to quickly test out some of the features, there's an included demo
 
 4. Now for the **impressive** part. Move your mouse over the number `15` and see it highlight. Now click and drag left or right, and see the view's corner radius update **in real time**. Awesome, huh?
 
+5. If you want to display an image from the iOS app, use the `.image` command. In our example, you can type `.image self redView generateImage`; the `generateImage` method will create a screenshot of the redView and the `.image` command will transfer it to the Mac app. This command works with any kind of image, you can do something like: `.image UIImage imageNamed:'Default.png'`.
+
 Using
 -----
 


### PR DESCRIPTION
Hi Jason,

I just added a command to transfer UIImages over JSTP and display them on the Mac client.

You can try:
.self
.image UIImage imageNamed:'Default'
.image self view generateImage
.image self redView generateImage

What do you think?

PS: the inclusion of NSData+Base64 should be done as a submodule, but as I think CocoaPods would be a better choice, I'll let you decide how to do this :-p).

PS2: this was really fun to implement! :-D

PS3: this time I forked the right repo… :-/
