### PR TITLE
Fixed issue with text input

### DIFF
--- a/SuperDBCore/SuperDBCore/FSArray.m
+++ b/SuperDBCore/SuperDBCore/FSArray.m
@@ -336,9 +336,13 @@ typedef struct fs_objc_object {
 {
   // fallback to printString (we may do something better in the future).
   // Note: super's implementation is not used because it won't work if the array contains nil.
-  return [self printString];
+    if ([self respondsToSelector:@selector(printString)]) {
+        return [self printString];
+    } else {
+        return [self debugDescription];
+    }
 }
-  
+
 - (void *)dataPtr
 {
   if (type != FS_ID) [self becomeArrayOfId];

--- a/SuperDBCore/SuperDBCore/SuperInterpreter.m
+++ b/SuperDBCore/SuperDBCore/SuperInterpreter.m
@@ -134,8 +134,15 @@
 	[self addRequestHandlerForResource:kSuperNetworkMessageResourceInterpreter requestHandler:^SuperNetworkMessage *(SuperNetworkMessage *request) {
 		
 		NSString *input = [[request body] objectForKey:kSuperNetworkMessageBodyInputKey];
+
+        // Fixed issue with F-Script mac editor using curly ' to wrap text
+        // .... replace ‘ and ’ with '
+        input = [input stringByReplacingOccurrencesOfString:@"‘" withString:@"'"];
+        input = [input stringByReplacingOccurrencesOfString:@"’" withString:@"'"];
+
 		FSInterpreterResult *result = [weakSelf interpreterResultForInput:input logResult:USE_LOGGING];
-		
+        
+        
 		NSMutableDictionary *body = [@{} mutableCopy];
 		
 		


### PR DESCRIPTION
when entering a 'text string' in the mac app shell, the shell turns the ' into a curly ' - the iOS app doesn't recognize it as a text string and it become really hard to enter text

this change searches the input string for curly ' and replaces them with straight '

it also fixes one other minor bug which should be safe
